### PR TITLE
Bugfix/dimension order czi fix

### DIFF
--- a/napari_allencell_segmenter/_tests/core/layer_reader_test.py
+++ b/napari_allencell_segmenter/_tests/core/layer_reader_test.py
@@ -6,7 +6,7 @@ from unittest import mock
 from unittest.mock import Mock, create_autospec
 from napari.layers._source import Source
 from napari_allencell_segmenter.core.layer_reader import LayerReader, Channel
-from ..mocks import MockLayer
+from napari_allencell_segmenter._tests.mocks import MockLayer
 
 
 class TestLayerReader:
@@ -70,6 +70,14 @@ class TestLayerReader:
         # Assert
         assert result.shape == (75, 100, 100)
         assert numpy.array_equal(result, input[index])
+
+
+        input = numpy.ones((2, 2, 4, 5, 6, 7))
+        layer = MockLayer(name="Test", data=input, ndim=6)  # 6D
+        result = self._layer_reader.get_channel_data(index, layer)
+        assert result.shape == (5, 6, 7)
+
+
 
     @pytest.mark.parametrize("index", range(0, 4))
     def test_get_channel_data_zcyx(self, index):

--- a/napari_allencell_segmenter/_tests/core/layer_reader_test.py
+++ b/napari_allencell_segmenter/_tests/core/layer_reader_test.py
@@ -71,13 +71,10 @@ class TestLayerReader:
         assert result.shape == (75, 100, 100)
         assert numpy.array_equal(result, input[index])
 
-
         input = numpy.ones((2, 2, 4, 5, 6, 7))
         layer = MockLayer(name="Test", data=input, ndim=6)  # 6D
         result = self._layer_reader.get_channel_data(index, layer)
         assert result.shape == (5, 6, 7)
-
-
 
     @pytest.mark.parametrize("index", range(0, 4))
     def test_get_channel_data_zcyx(self, index):

--- a/napari_allencell_segmenter/_tests/core/layer_reader_test.py
+++ b/napari_allencell_segmenter/_tests/core/layer_reader_test.py
@@ -65,7 +65,7 @@ class TestLayerReader:
         layer = MockLayer(name="Test", data=input, ndim=4)  # 4D
 
         # Act
-        result = self._layer_reader.get_channel_data(index, layer)
+        result = self._layer_reader.zget_channel_data(index, layer)
 
         # Assert
         assert result.shape == (75, 100, 100)

--- a/napari_allencell_segmenter/_tests/core/layer_reader_test.py
+++ b/napari_allencell_segmenter/_tests/core/layer_reader_test.py
@@ -17,7 +17,7 @@ class TestLayerReader:
         channels = self._layer_reader.get_channels(None)
         assert channels is None
 
-    @pytest.mark.parametrize("data", [numpy.ones((75, 4, 100, 200))]) # ZCYX, CZYX
+    @pytest.mark.parametrize("data", [numpy.ones((75, 4, 100, 200))])  # ZCYX, CZYX
     def test_get_channels(self, data):
         # Arrange
         layer = MockLayer(name="Test", data=data)
@@ -34,9 +34,11 @@ class TestLayerReader:
     def test_get_channels_from_layer_source(self, mock_aics_image: Mock):
         # Arrange
         mock_image = create_autospec(AICSImage)
+
         mock_aics_image.return_value = mock_image
         img_path = "/path/to/image.tiff"
         layer = MockLayer(name="Test", source=Source(path=img_path, reader_plugin="builtins"))
+
         mock_image.get_channel_names.return_value = ["Test1", "Test2", "Test3"]
 
         # Act

--- a/napari_allencell_segmenter/_tests/core/layer_reader_test.py
+++ b/napari_allencell_segmenter/_tests/core/layer_reader_test.py
@@ -65,7 +65,7 @@ class TestLayerReader:
         layer = MockLayer(name="Test", data=input, ndim=4)  # 4D
 
         # Act
-        result = self._layer_reader.zget_channel_data(index, layer)
+        result = self._layer_reader.get_channel_data(index, layer)
 
         # Assert
         assert result.shape == (75, 100, 100)

--- a/napari_allencell_segmenter/_tests/core/layer_reader_test.py
+++ b/napari_allencell_segmenter/_tests/core/layer_reader_test.py
@@ -39,7 +39,8 @@ class TestLayerReader:
         img_path = "/path/to/image.tiff"
         layer = MockLayer(name="Test", source=Source(path=img_path, reader_plugin="builtins"))
 
-        mock_image.get_channel_names.return_value = ["Test1", "Test2", "Test3"]
+        mock_channels = Mock(return_value=["Test1", "Test2", "Test3"])
+        mock_image.channel_names = mock_channels.return_value
 
         # Act
         channels = self._layer_reader.get_channels(layer)

--- a/napari_allencell_segmenter/_tests/core/layer_reader_test.py
+++ b/napari_allencell_segmenter/_tests/core/layer_reader_test.py
@@ -17,7 +17,7 @@ class TestLayerReader:
         channels = self._layer_reader.get_channels(None)
         assert channels is None
 
-    @pytest.mark.parametrize("data", [numpy.ones((75, 4, 100, 200))])  # ZCYX, CZYX
+    @pytest.mark.parametrize("data", [numpy.ones((75, 4, 100, 200)), numpy.ones((75, 10, 300, 200))])  # ZCYX, CZYX
     def test_get_channels(self, data):
         # Arrange
         layer = MockLayer(name="Test", data=data)

--- a/napari_allencell_segmenter/_tests/core/layer_reader_test.py
+++ b/napari_allencell_segmenter/_tests/core/layer_reader_test.py
@@ -17,7 +17,7 @@ class TestLayerReader:
         channels = self._layer_reader.get_channels(None)
         assert channels is None
 
-    @pytest.mark.parametrize("data", [numpy.ones((75, 4, 100, 200)), numpy.ones((4, 75, 100, 200))])  # ZCYX, CZYX
+    @pytest.mark.parametrize("data", [numpy.ones((75, 4, 100, 200))]) # ZCYX, CZYX
     def test_get_channels(self, data):
         # Arrange
         layer = MockLayer(name="Test", data=data)
@@ -27,7 +27,8 @@ class TestLayerReader:
 
         # Assert
         assert channels is not None
-        assert len(channels) == 4
+        # we use aicsimageio which thinks the image is in CZYX format, channels = 75
+        assert len(channels) == 75
 
     @mock.patch("napari_allencell_segmenter.core.layer_reader.AICSImage")
     def test_get_channels_from_layer_source(self, mock_aics_image: Mock):
@@ -77,8 +78,10 @@ class TestLayerReader:
         result = self._layer_reader.get_channel_data(index, layer)
 
         # Assert
-        assert result.shape == (75, 100, 200)
-        assert numpy.array_equal(result, input[:, index, :, :])
+        # no matter what, AICSIMAGE reads the numpy arrays as CZYX
+        # and returns ZYX
+        assert result.shape == (4, 100, 200)
+        assert numpy.array_equal(result, input[index, :, :, :])
 
     @mock.patch("napari_allencell_segmenter.core.layer_reader.AICSImage")
     def test_get_channel_data_from_layer_source(self, mock_aics_image):

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -52,7 +52,7 @@ class LayerReader:
         img = AICSImage(image_path)
 
         channels = list()
-        for index, name in enumerate(img.get_channel_names()):
+        for index, name in enumerate(img.channel_names):
             channels.append(Channel(index, name))
         return channels
 

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -55,7 +55,6 @@ class LayerReader:
         return channels
 
     def _get_channels_from_path(self, image_path: str) -> List[Channel]:
-        #TODO: test if scenes work with file path opens
         img = AICSImage(image_path)
 
         channels = list()

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -40,10 +40,8 @@ class LayerReader:
         img = AICSImage(layer.data)  # gives us a 6D image
 
         # we're expecting either STCZYX or STZCYX but we don't know for sure
-        # Attempt to guess based on array length. Channels array should be shorter in general.
-        index_c = 2
-        if img.shape[2] > img.shape[3]:
-            index_c = 3
+        # Attempt to guess based on array length. Channels array should be shorter in general.'
+        index_c = img.dims.order.index('C')
 
         channels = list()
         for index in range(img.shape[index_c]):
@@ -88,10 +86,14 @@ class LayerReader:
 
         # we're expecting either STCZYX or STZCYX but we don't know for sure
         # Attempt to guess based on array length. Channels array should be shorter in general.
-        if img.shape[2] > img.shape[3]:
-            return img.data[0, 0, :, channel_index, :, :]  # STZCYX
-
-        return img.data[0, 0, channel_index, :, :, :]  # STCZYX
+        # if img.shape[2] > img.shape[3]:
+        #     return img.data[0, 0, :, channel_index, :, :]  # STZCYX
+        #
+        # return img.data[0, 0, channel_index, :, :, :]  # STCZYX
+        if len(img.data.shape) == 4:
+            return img.get_image_data("TZCYX")
+        else:
+            return img.get_image_data("STZCYX")
 
     def _get_channel_data_from_path(self, channel_index: int, image_path: str):
         img = AICSImage(image_path)

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -44,6 +44,7 @@ class LayerReader:
         else:
             image_from_layer = layer.data
         img = AICSImage(image_from_layer)  # gives us a 6D image#
+        img.set_scene(0)
 
         # we're expecting either STCZYX or STZCYX but we don't know for sure
         # Attempt to guess based on array length. Channels array should be shorter in general.'
@@ -56,6 +57,7 @@ class LayerReader:
 
     def _get_channels_from_path(self, image_path: str) -> List[Channel]:
         img = AICSImage(image_path)
+        img.set_scene(0)
 
         channels = list()
         for index, name in enumerate(img.channel_names):

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -41,7 +41,7 @@ class LayerReader:
 
         # we're expecting either STCZYX or STZCYX but we don't know for sure
         # Attempt to guess based on array length. Channels array should be shorter in general.'
-        index_c = img.dims.order.index('C')
+        index_c = img.dims.order.index("C")
 
         channels = list()
         for index in range(img.shape[index_c]):

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -84,16 +84,9 @@ class LayerReader:
     def _get_channel_data_default(self, channel_index: int, layer: Layer):
         img = AICSImage(layer.data)  # gives us a 6D image
 
-        # we're expecting either STCZYX or STZCYX but we don't know for sure
-        # Attempt to guess based on array length. Channels array should be shorter in general.
-        # if img.shape[2] > img.shape[3]:
-        #     return img.data[0, 0, :, channel_index, :, :]  # STZCYX
-        #
-        # return img.data[0, 0, channel_index, :, :, :]  # STCZYX
-        if len(img.data.shape) == 4:
-            return img.get_image_data("TZCYX")
-        else:
-            return img.get_image_data("STZCYX")
+        # use get_image_data() to parse out ZYX dimensions
+        # segmenter requries 3D images.
+        return img.get_image_data("ZYX", T=0, S=0, C=channel_index)
 
     def _get_channel_data_from_path(self, channel_index: int, image_path: str):
         img = AICSImage(image_path)

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -37,7 +37,6 @@ class LayerReader:
         return self._get_channels_default(layer)
 
     def _get_channels_default(self, layer: Layer) -> List[Channel]:
-
         if len(layer.data.shape) >= 6:
             # Has scenes
             image_from_layer = [layer.data[i, :, :, :, :, :] for i in range(layer.data.shape[0])]

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -46,8 +46,6 @@ class LayerReader:
         img = AICSImage(image_from_layer)  # gives us a 6D image#
         img.set_scene(0)
 
-        # we're expecting either STCZYX or STZCYX but we don't know for sure
-        # Attempt to guess based on array length. Channels array should be shorter in general.'
         index_c = img.dims.order.index("C")
 
         channels = list()

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -37,7 +37,7 @@ class LayerReader:
         return self._get_channels_default(layer)
 
     def _get_channels_default(self, layer: Layer) -> List[Channel]:
-        if len(layer.data.shape) >= 6:
+        if len(layer.data.shape) == 6:
             # Has scenes
             image_from_layer = [layer.data[i, :, :, :, :, :] for i in range(layer.data.shape[0])]
         else:

--- a/napari_allencell_segmenter/core/layer_reader.py
+++ b/napari_allencell_segmenter/core/layer_reader.py
@@ -37,7 +37,7 @@ class LayerReader:
         return self._get_channels_default(layer)
 
     def _get_channels_default(self, layer: Layer) -> List[Channel]:
-        img = AICSImage(layer.data)  # gives us a 6D image
+        img = AICSImage(layer.data)  # gives us a 6D image#
 
         # we're expecting either STCZYX or STZCYX but we don't know for sure
         # Attempt to guess based on array length. Channels array should be shorter in general.'

--- a/napari_allencell_segmenter/view/workflow_steps_view.py
+++ b/napari_allencell_segmenter/view/workflow_steps_view.py
@@ -150,7 +150,11 @@ class WorkflowStepsView(View):  # pragma: no-cover
     def _setup_diagram_window(self):
         self.window_workflow_diagram = QScrollArea()
         diagram = QLabel()
-        img_data = np.moveaxis(self._workflow.workflow_definition.diagram_image, 0, -1)
+        #TODO: remove this when dimension order refactor happens
+        color_channel_size: int = min(np.shape(self._workflow.workflow_definition.diagram_image))
+        min_index: int = np.shape(self._workflow.workflow_definition.diagram_image).index(color_channel_size)
+
+        img_data = np.moveaxis(self._workflow.workflow_definition.diagram_image, min_index, -1)
         img = QImage(img_data, img_data.shape[1], img_data.shape[0], QImage.Format.Format_RGB888)
         diagram.setPixmap(QPixmap(img).scaledToWidth(1000, Qt.TransformationMode.SmoothTransformation))
 

--- a/napari_allencell_segmenter/view/workflow_steps_view.py
+++ b/napari_allencell_segmenter/view/workflow_steps_view.py
@@ -150,7 +150,7 @@ class WorkflowStepsView(View):  # pragma: no-cover
     def _setup_diagram_window(self):
         self.window_workflow_diagram = QScrollArea()
         diagram = QLabel()
-        #TODO: remove this when dimension order refactor happens
+        # TODO: remove this when dimension order refactor happens
         color_channel_size: int = min(np.shape(self._workflow.workflow_definition.diagram_image))
         min_index: int = np.shape(self._workflow.workflow_definition.diagram_image).index(color_channel_size)
 

--- a/napari_allencell_segmenter/widgets/workflow_thumbnails.py
+++ b/napari_allencell_segmenter/widgets/workflow_thumbnails.py
@@ -101,13 +101,19 @@ class WorkflowThumbnails(QWidget):
             # TODO?: convert all images to RBGA
             pre: np.ndarray = workflow.thumbnail_pre
             post: np.ndarray = workflow.thumbnail_post
+
+            #TODO: We need a way to a) track dimension order if present in metadata and b) try to guess dimension order
+            color_channel_size: int = min(np.shape(workflow.thumbnail_pre))
+            min_index: int = np.shape(workflow.thumbnail_pre).index(color_channel_size)
+
+
             # If RGBA convert to grayscale
             if len(workflow.thumbnail_pre.shape) > 2:
                 # cv2 expects color channel dim to be last index
-                pre = cv2.cvtColor(np.moveaxis(workflow.thumbnail_pre, 0, -1), cv2.COLOR_RGBA2GRAY)
+                pre = cv2.cvtColor(np.moveaxis(workflow.thumbnail_pre, min_index, -1), cv2.COLOR_RGBA2GRAY)
             if len(workflow.thumbnail_post.shape) > 2:
                 # cv2 expects color channel dim to be last index
-                post = cv2.cvtColor(np.moveaxis(workflow.thumbnail_post, 0, -1), cv2.COLOR_RGBA2GRAY)
+                post = cv2.cvtColor(np.moveaxis(workflow.thumbnail_post, min_index, -1), cv2.COLOR_RGBA2GRAY)
             # Stitch Image
             image_stitched: np.ndarray = np.hstack([pre, post])
             button: QPushButton = QPushButton("")

--- a/napari_allencell_segmenter/widgets/workflow_thumbnails.py
+++ b/napari_allencell_segmenter/widgets/workflow_thumbnails.py
@@ -102,10 +102,9 @@ class WorkflowThumbnails(QWidget):
             pre: np.ndarray = workflow.thumbnail_pre
             post: np.ndarray = workflow.thumbnail_post
 
-            #TODO: We need a way to a) track dimension order if present in metadata and b) try to guess dimension order
+            # TODO: We need a way to a) track dimension order if present in metadata and b) try to guess dimension order
             color_channel_size: int = min(np.shape(workflow.thumbnail_pre))
             min_index: int = np.shape(workflow.thumbnail_pre).index(color_channel_size)
-
 
             # If RGBA convert to grayscale
             if len(workflow.thumbnail_pre.shape) > 2:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ dev_requirements = [
     "wheel>=0.33.1",
 ]
 
-setup_requirements = [    
+setup_requirements = [
     "pytest-runner",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy",
     "aicssegmentation == 0.4.0",
     "magicgui >= 0.2.9",
-    "aicsimageio == 4.1.0",
+    "aicsimageio ~= 4.0.5",
     "opencv-python-headless>=4.5.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy",
     "aicssegmentation >= 0.3.0",
     "magicgui >= 0.2.9",
-    "aicsimageio>=3.3.6",
+    "aicsimageio==4.0.5",
     "opencv-python-headless>=4.5.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy",
     "aicssegmentation >= 0.3.0",
     "magicgui >= 0.2.9",
-    "aicsimageio==4.0.0.dev9",
+    "aicsimageio >=3.3.6 <4",
     "opencv-python-headless>=4.5.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy",
     "aicssegmentation >= 0.3.0",
     "magicgui >= 0.2.9",
-    "aicsimageio >=3.3.6 <4",
+    "aicsimageio >=3.3.6,<4",
     "opencv-python-headless>=4.5.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ requirements = [
     "napari>=0.4.9",
     "napari-plugin-engine>=0.1.4",
     "numpy",
-    "aicssegmentation >= 0.3.0",
+    "aicssegmentation == 0.4.0",
     "magicgui >= 0.2.9",
-    "aicsimageio >=3.3.6,<4",
+    "aicsimageio == 4.1.0",
     "opencv-python-headless>=4.5.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy",
     "aicssegmentation >= 0.3.0",
     "magicgui >= 0.2.9",
-    "aicsimageio==4.0.5",
+    "aicsimageio==4.0.0.dev9",
     "opencv-python-headless>=4.5.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "numpy",
     "aicssegmentation >= 0.3.0",
     "magicgui >= 0.2.9",
-    "aicsimageio>=3.3.6,<4",
+    "aicsimageio>=3.3.6",
     "opencv-python-headless>=4.5.1",
 ]
 


### PR DESCRIPTION
Fix for https://github.com/AllenCell/napari-allencell-segmenter/issues/116 and https://github.com/AllenCell/napari-allencell-segmenter/issues/117

- CZI images have a format we did not expect. We used to guess dimension order, which worked well for TIFF, but to support CZI images we now use AICSImageIO to get the correct dimensions out of CZI and TIFF images.
- For thumbnails we do not use AICSImageIO, so I changed the way the plugin guesses the color channel to work for CZI as well as TIFF
- Took out guessing whenever possible to use AICSImageIO for reliability
- Unpinned <4 version pin on AICSImageIO, which causes [dependency issues](https://github.com/AllenCell/napari-allencell-segmenter/issues/117)
