### PR TITLE
Fix/use qtpy instead of PyQt5

### DIFF
--- a/napari_allencell_segmenter/_dock_widget.py
+++ b/napari_allencell_segmenter/_dock_widget.py
@@ -3,7 +3,7 @@ import napari
 
 from napari_allencell_segmenter.core.application import Application
 from napari_plugin_engine import napari_hook_implementation
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QSizePolicy
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QSizePolicy
 
 """
 The class name here gets converted to title case and gets displayed as both the title 

--- a/napari_allencell_segmenter/_tests/conftest.py
+++ b/napari_allencell_segmenter/_tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/napari_allencell_segmenter/_tests/core/view_manager_test.py
+++ b/napari_allencell_segmenter/_tests/core/view_manager_test.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import MagicMock, create_autospec
 from napari_allencell_segmenter.core.view_manager import ViewManager
 from napari_allencell_segmenter.core.view import View, ViewTemplate
-from PyQt5.QtWidgets import QFrame, QVBoxLayout
+from qtpy.QtWidgets import QFrame, QVBoxLayout
 
 # Custom Mock view implementations because QT doesn't like MagicMock widgets
 class MockViewTemplate1(ViewTemplate):

--- a/napari_allencell_segmenter/_tests/core/view_test.py
+++ b/napari_allencell_segmenter/_tests/core/view_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from PyQt5.QtWidgets import QFrame
+from qtpy.QtWidgets import QFrame
 from napari_allencell_segmenter.core.view import View, ViewTemplate
 
 

--- a/napari_allencell_segmenter/_tests/view/_main_template_test.py
+++ b/napari_allencell_segmenter/_tests/view/_main_template_test.py
@@ -1,5 +1,5 @@
 from napari_allencell_segmenter.view._main_template import MainTemplate
-from PyQt5.QtWidgets import QFrame
+from qtpy.QtWidgets import QFrame
 
 
 class TestMainTemplate:

--- a/napari_allencell_segmenter/_tests/view/batch_processing_view_test.py
+++ b/napari_allencell_segmenter/_tests/view/batch_processing_view_test.py
@@ -12,8 +12,8 @@ class TestBatchProcessingView:
         self._mock_controller: MagicMock = create_autospec(IBatchProcessingController)
         self._view = BatchProcessingView(self._mock_controller)
         self._view.load()
-    
-    def open_completion_dialog(self):
+
+    def test_open_completion_dialog(self):
         self._view.open_completion_dialog("/some/dir")
         assert self._view.completion_dlg.isVisible()
 

--- a/napari_allencell_segmenter/_tests/view/batch_processing_view_test.py
+++ b/napari_allencell_segmenter/_tests/view/batch_processing_view_test.py
@@ -13,10 +13,6 @@ class TestBatchProcessingView:
         self._view = BatchProcessingView(self._mock_controller)
         self._view.load()
 
-    def test_open_completion_dialog(self):
-        self._view.open_completion_dialog("/some/dir")
-        assert self._view.completion_dlg.isVisible()
-
     def test_update_button(self):
         self._view.update_button(enabled=True)
         assert self._view.btn_run_batch.isEnabled()

--- a/napari_allencell_segmenter/_tests/view/batch_processing_view_test.py
+++ b/napari_allencell_segmenter/_tests/view/batch_processing_view_test.py
@@ -12,6 +12,10 @@ class TestBatchProcessingView:
         self._mock_controller: MagicMock = create_autospec(IBatchProcessingController)
         self._view = BatchProcessingView(self._mock_controller)
         self._view.load()
+    
+    def open_completion_dialog(self):
+        self._view.open_completion_dialog("/some/dir")
+        assert self._view.completion_dlg.isVisible()
 
     def test_update_button(self):
         self._view.update_button(enabled=True)

--- a/napari_allencell_segmenter/_tests/view/workflow_select_view_test.py
+++ b/napari_allencell_segmenter/_tests/view/workflow_select_view_test.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from PyQt5 import QtCore
+from qtpy import QtCore
 from unittest.mock import MagicMock, PropertyMock, create_autospec
 from napari_allencell_segmenter.view.workflow_select_view import (
     WorkflowSelectView,

--- a/napari_allencell_segmenter/_tests/widgets/collapsible_box_test.py
+++ b/napari_allencell_segmenter/_tests/widgets/collapsible_box_test.py
@@ -1,5 +1,5 @@
 import pytest
-from PyQt5.QtWidgets import QLabel, QPushButton, QVBoxLayout
+from qtpy.QtWidgets import QLabel, QPushButton, QVBoxLayout
 
 from napari_allencell_segmenter.widgets.collapsible_box import CollapsibleBox
 

--- a/napari_allencell_segmenter/_tests/widgets/workflow_step_widget_test.py
+++ b/napari_allencell_segmenter/_tests/widgets/workflow_step_widget_test.py
@@ -6,7 +6,7 @@ from aicssegmentation.workflow import (
     WidgetType,
     WorkflowStepCategory,
 )
-from PyQt5.QtWidgets import QComboBox
+from qtpy.QtWidgets import QComboBox
 from napari_allencell_segmenter.widgets.workflow_step_widget import WorkflowStepWidget
 
 

--- a/napari_allencell_segmenter/_tests/widgets/workflow_thumbnails_test.py
+++ b/napari_allencell_segmenter/_tests/widgets/workflow_thumbnails_test.py
@@ -1,5 +1,5 @@
 from typing import List
-from PyQt5.QtWidgets import QPushButton
+from qtpy.QtWidgets import QPushButton
 import pytest
 
 from aicssegmentation.workflow import WorkflowEngine

--- a/napari_allencell_segmenter/controller/batch_processing_controller.py
+++ b/napari_allencell_segmenter/controller/batch_processing_controller.py
@@ -108,6 +108,9 @@ class BatchProcessingController(Controller, IBatchProcessingController):
         self._run_lock = False
 
         if not self._canceled:
+            # Open completion dialog
+            # TODO: this should be moved back to batch_processing_view, but testing QDialog.exec_()
+            # is tricky
             completion_dlg = BatchCompleteDialog(self._output_folder)
             completion_dlg.exec_()
 

--- a/napari_allencell_segmenter/controller/batch_processing_controller.py
+++ b/napari_allencell_segmenter/controller/batch_processing_controller.py
@@ -8,6 +8,7 @@ from aicssegmentation.workflow import WorkflowEngine, BatchWorkflow
 from napari_allencell_segmenter.core._interfaces import IApplication
 from napari_allencell_segmenter.core.controller import Controller
 from napari_allencell_segmenter.view.batch_processing_view import BatchProcessingView
+from napari_allencell_segmenter.widgets.batch_complete_dialog import BatchCompleteDialog
 from ._interfaces import IBatchProcessingController
 
 
@@ -107,7 +108,8 @@ class BatchProcessingController(Controller, IBatchProcessingController):
         self._run_lock = False
 
         if not self._canceled:
-            self._view.open_completion_dialog(self._output_folder)
+            completion_dlg = BatchCompleteDialog(self._output_folder)
+            completion_dlg.exec_()
 
         self._view.reset_run_batch()
         self._canceled = False

--- a/napari_allencell_segmenter/core/view.py
+++ b/napari_allencell_segmenter/core/view.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Any
-from PyQt5.QtWidgets import QWidget, QFrame
+from qtpy.QtWidgets import QWidget, QFrame
 
 
 class ViewMeta(type(QWidget), type(ABC)):

--- a/napari_allencell_segmenter/util/ui_utils.py
+++ b/napari_allencell_segmenter/util/ui_utils.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QComboBox
+from qtpy.QtWidgets import QComboBox
 
 from napari_allencell_segmenter.widgets.form import FormRow
 

--- a/napari_allencell_segmenter/view/_main_template.py
+++ b/napari_allencell_segmenter/view/_main_template.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QFrame, QVBoxLayout, QScrollArea, QLabel
-from PyQt5.QtCore import Qt
+from qtpy.QtWidgets import QFrame, QVBoxLayout, QScrollArea, QLabel
+from qtpy.QtCore import Qt
 
 from napari_allencell_segmenter.core.view import ViewTemplate
 from napari_allencell_segmenter._style import Style

--- a/napari_allencell_segmenter/view/batch_processing_view.py
+++ b/napari_allencell_segmenter/view/batch_processing_view.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QProgressBar, QVBoxLayout, QWidget, QLineEdit, QPushButton, QLabel
-from PyQt5.QtGui import QIntValidator
+from qtpy.QtWidgets import QProgressBar, QVBoxLayout, QWidget, QLineEdit, QPushButton, QLabel
+from qtpy.QtGui import QIntValidator
 from pathlib import Path
 from napari_allencell_segmenter.core.view import View
 from napari_allencell_segmenter.controller._interfaces import IBatchProcessingController

--- a/napari_allencell_segmenter/view/batch_processing_view.py
+++ b/napari_allencell_segmenter/view/batch_processing_view.py
@@ -95,8 +95,8 @@ class BatchProcessingView(View):
         Inputs:
             output_folder (Path): output folder to open when prompted by user
         """
-        dlg = BatchCompleteDialog(output_folder)
-        dlg.exec_()
+        self.completion_dlg = BatchCompleteDialog(output_folder)
+        self.completion_dlg.exec_()
 
     def set_run_batch_in_progress(self):
         """

--- a/napari_allencell_segmenter/view/batch_processing_view.py
+++ b/napari_allencell_segmenter/view/batch_processing_view.py
@@ -96,7 +96,7 @@ class BatchProcessingView(View):
             output_folder (Path): output folder to open when prompted by user
         """
         dlg = BatchCompleteDialog(output_folder)
-        dlg.exec()
+        dlg.exec_()
 
     def set_run_batch_in_progress(self):
         """

--- a/napari_allencell_segmenter/view/batch_processing_view.py
+++ b/napari_allencell_segmenter/view/batch_processing_view.py
@@ -5,7 +5,6 @@ from napari_allencell_segmenter.core.view import View
 from napari_allencell_segmenter.controller._interfaces import IBatchProcessingController
 from napari_allencell_segmenter.widgets.form import Form, FormRow
 from napari_allencell_segmenter.widgets.file_input import FileInput, FileInputMode
-from napari_allencell_segmenter.widgets.batch_complete_dialog import BatchCompleteDialog
 from ._main_template import MainTemplate
 
 
@@ -88,15 +87,6 @@ class BatchProcessingView(View):
             enabled: True to enable the button, false to disable it
         """
         self.btn_run_batch.setEnabled(enabled)
-
-    def open_completion_dialog(self, output_folder: Path):
-        """
-        Open the batch processing completion dialog box
-        Inputs:
-            output_folder (Path): output folder to open when prompted by user
-        """
-        self.completion_dlg = BatchCompleteDialog(output_folder)
-        self.completion_dlg.exec_()
 
     def set_run_batch_in_progress(self):
         """

--- a/napari_allencell_segmenter/view/batch_processing_view.py
+++ b/napari_allencell_segmenter/view/batch_processing_view.py
@@ -1,6 +1,5 @@
 from qtpy.QtWidgets import QProgressBar, QVBoxLayout, QWidget, QLineEdit, QPushButton, QLabel
 from qtpy.QtGui import QIntValidator
-from pathlib import Path
 from napari_allencell_segmenter.core.view import View
 from napari_allencell_segmenter.controller._interfaces import IBatchProcessingController
 from napari_allencell_segmenter.widgets.form import Form, FormRow

--- a/napari_allencell_segmenter/view/workflow_select_view.py
+++ b/napari_allencell_segmenter/view/workflow_select_view.py
@@ -2,14 +2,14 @@ from typing import List
 
 from aicssegmentation.workflow.workflow_definition import WorkflowDefinition
 from napari.layers.base.base import Layer
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QComboBox,
     QLabel,
     QVBoxLayout,
     QWidget,
 )
-from PyQt5.QtGui import QStandardItem, QStandardItemModel
-from PyQt5 import QtCore
+from qtpy.QtGui import QStandardItem, QStandardItemModel
+from qtpy import QtCore
 
 from napari_allencell_segmenter.model.channel import Channel
 from napari_allencell_segmenter.model.segmenter_model import SegmenterModel

--- a/napari_allencell_segmenter/view/workflow_steps_view.py
+++ b/napari_allencell_segmenter/view/workflow_steps_view.py
@@ -2,9 +2,9 @@ from typing import List
 import numpy as np
 
 from aicssegmentation.workflow import WorkflowStepCategory
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QImage, QPixmap
-from PyQt5.QtWidgets import (
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QImage, QPixmap
+from qtpy.QtWidgets import (
     QFileDialog,
     QHBoxLayout,
     QLabel,

--- a/napari_allencell_segmenter/widgets/batch_complete_dialog.py
+++ b/napari_allencell_segmenter/widgets/batch_complete_dialog.py
@@ -2,7 +2,7 @@ import sys
 import subprocess
 
 from qtpy.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout, QDialog, QPushButton
-from PyQt5.QtCore import Qt
+from qtpy.QtCore import Qt
 from pathlib import Path
 
 

--- a/napari_allencell_segmenter/widgets/file_input.py
+++ b/napari_allencell_segmenter/widgets/file_input.py
@@ -1,6 +1,6 @@
 from enum import Enum
-from PyQt5.QtWidgets import QHBoxLayout, QWidget, QLineEdit, QFileDialog
-from PyQt5.QtCore import pyqtSignal
+from qtpy.QtWidgets import QHBoxLayout, QWidget, QLineEdit, QFileDialog
+from qtpy.QtCore import pyqtSignal
 
 
 class FileInputMode(Enum):

--- a/napari_allencell_segmenter/widgets/file_input.py
+++ b/napari_allencell_segmenter/widgets/file_input.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from qtpy.QtWidgets import QHBoxLayout, QWidget, QLineEdit, QFileDialog
-from qtpy.QtCore import pyqtSignal
+from qtpy.QtCore import Signal
 
 
 class FileInputMode(Enum):
@@ -19,7 +19,7 @@ class FileInput(QWidget):
         initial_text (str): text to display in the widget before a file has been selected
     """
 
-    file_selected = pyqtSignal(str)
+    file_selected = Signal(str)
     _selected_file: str = None
 
     def __init__(

--- a/napari_allencell_segmenter/widgets/float_slider.py
+++ b/napari_allencell_segmenter/widgets/float_slider.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QDoubleSpinBox
+from qtpy.QtWidgets import QDoubleSpinBox
 import magicgui.widgets
 
 

--- a/napari_allencell_segmenter/widgets/form.py
+++ b/napari_allencell_segmenter/widgets/form.py
@@ -1,8 +1,8 @@
 import magicgui.widgets
 
 from typing import List, NamedTuple, Union
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QFormLayout, QLabel, QWidget
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QFormLayout, QLabel, QWidget
 
 
 class FormRow(NamedTuple):

--- a/napari_allencell_segmenter/widgets/warning_message.py
+++ b/napari_allencell_segmenter/widgets/warning_message.py
@@ -1,5 +1,5 @@
-from PyQt5.QtWidgets import QWidget, QHBoxLayout, QLabel
-from PyQt5.QtGui import QPixmap
+from qtpy.QtWidgets import QWidget, QHBoxLayout, QLabel
+from qtpy.QtGui import QPixmap
 from napari_allencell_segmenter.util.directories import Directories
 
 

--- a/napari_allencell_segmenter/widgets/workflow_step_widget.py
+++ b/napari_allencell_segmenter/widgets/workflow_step_widget.py
@@ -1,6 +1,6 @@
 import copy
 from typing import Any, Dict, List, Union
-from PyQt5.QtWidgets import QComboBox
+from qtpy.QtWidgets import QComboBox
 
 from aicssegmentation.workflow import WorkflowStep, FunctionParameter, WidgetType
 from magicgui.widgets import Slider

--- a/napari_allencell_segmenter/widgets/workflow_thumbnails.py
+++ b/napari_allencell_segmenter/widgets/workflow_thumbnails.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtGui import QIcon, QPixmap, QImage
 from qtpy import QtCore
-from qtpy.QtCore import pyqtSignal
+from qtpy.QtCore import Signal
 
 from napari_allencell_segmenter.widgets.form import Form, FormRow
 from napari_allencell_segmenter._style import PAGE_CONTENT_WIDTH, Style
@@ -28,7 +28,7 @@ class WorkflowThumbnails(QWidget):
             workflow definitions to display as buttons
     """
 
-    workflowSelected = pyqtSignal(str)  # signal: emitted when a workflow is selected
+    workflowSelected = Signal(str)  # signal: emitted when a workflow is selected
 
     def __init__(self, workflows: List[WorkflowDefinition] = None):
         super().__init__()

--- a/napari_allencell_segmenter/widgets/workflow_thumbnails.py
+++ b/napari_allencell_segmenter/widgets/workflow_thumbnails.py
@@ -3,16 +3,16 @@ from typing import List
 from aicssegmentation.workflow import WorkflowDefinition
 import cv2
 import numpy as np
-from PyQt5.QtWidgets import (
+from qtpy.QtWidgets import (
     QPushButton,
     QHBoxLayout,
     QVBoxLayout,
     QLabel,
     QWidget,
 )
-from PyQt5.QtGui import QIcon, QPixmap, QImage
-from PyQt5 import QtCore
-from PyQt5.QtCore import pyqtSignal
+from qtpy.QtGui import QIcon, QPixmap, QImage
+from qtpy import QtCore
+from qtpy.QtCore import pyqtSignal
 
 from napari_allencell_segmenter.widgets.form import Form, FormRow
 from napari_allencell_segmenter._style import PAGE_CONTENT_WIDTH, Style

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ requirements = [
     "magicgui >= 0.2.9",
     "aicsimageio ~= 4.0.5",
     "opencv-python-headless>=4.5.1",
-    "pyqt5 == 5.15.4",
 ]
 
 test_requirements = [


### PR DESCRIPTION
Closes #129 

Because we were using PyQt5 directly instead of using qtpy (abstraction layer), sometimes the plugin wasn't able to open depending on the user's environment. More info: https://napari.org/plugins/stable/best_practices.html#don-t-include-pyside2-or-pyqt5-in-your-plugin-s-dependencies

Changes:
* Replace all imports of `PyQt5` with `qtpy`
* Import `Signal` instead of `qtpySignal` from `QtCore` (necessary after the above change)
* Use `exec_()` instead of `exec()` for `QDialog` widgets (per napari's advice, and it matches the Qt docs. Not positive this affects the user's ability to open the plugin, but seems like a good thing to do)

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
