### PR TITLE
documentation/categories-for-napari-hub

### DIFF
--- a/.github/workflows/plugin_preview.yml
+++ b/.github/workflows/plugin_preview.yml
@@ -1,0 +1,21 @@
+name: napari hub Preview Page # we use this name to find your preview page artifact, so don't change it!
+# For more info on this action, see https://github.com/chanzuckerberg/napari-hub-preview-action/blob/main/action.yml
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  preview-page:
+    name: Preview Page Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: napari hub Preview Page Builder
+        uses: chanzuckerberg/napari-hub-preview-action@v0.1.5
+        with:
+          hub-ref: main

--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -2,4 +2,12 @@ project_urls:
   Bug Tracker: https://github.com/AllenCell/napari-allencell-segmenter/issues
   Documentation: https://github.com/AllenCell/napari-allencell-segmenter#README.md
   Source Code: https://github.com/AllenCell/napari-allencell-segmenter
-  User Support: https://github.com/AllenCell/napari-allencell-segmenter/issues
+  User Support: https://github.com/AllenCell/napari-allencell-segmenter/issues# Add labels from the EDAM Bioimaging ontology
+labels:
+  ontology: EDAM-BIOIMAGING:alpha06
+  terms:
+  - 3D image
+  - Cell segmentation
+  - Model-based segmentation
+  - Fluorescence microscopy
+  - Image visualisation

--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -2,7 +2,9 @@ project_urls:
   Bug Tracker: https://github.com/AllenCell/napari-allencell-segmenter/issues
   Documentation: https://github.com/AllenCell/napari-allencell-segmenter#README.md
   Source Code: https://github.com/AllenCell/napari-allencell-segmenter
-  User Support: https://github.com/AllenCell/napari-allencell-segmenter/issues# Add labels from the EDAM Bioimaging ontology
+  User Support: https://github.com/AllenCell/napari-allencell-segmenter/issues
+
+# Add labels from the EDAM Bioimaging ontology
 labels:
   ontology: EDAM-BIOIMAGING:alpha06
   terms:


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!


# Add categories and preview page workflow for the napari hub

Hello!

I’m Justin Kiggins, the Product Manager at CZI leading our work on the [napari hub](https://napari-hub.org/).

I’m reaching out with this pull request to ask for your help preparing your plugin for a new “Filter by Category” feature we’ll be launching for the napari hub near the end of January.

This PR does 2 things:

1. adds our proposed labels to `.napari/config.yml` to help users find your plugin
2. adds an Action to your repository in `.github/workflows/plugin_preview.yml` to help you preview changes to your plugin’s napari hub page 

### What is the “Filter by Category” feature?

We will [let users filter plugins on the napari hub by Category](https://github.com/chanzuckerberg/napari-hub/issues/240), based on your own annotations of your plugin selected fro terms in the [EDAM Bioimaging ontology](https://github.com/edamontology/edam-bioimaging). You are able to specify, in your `.napari/config.yml` file, any number of EDAM labels at whatever depth of the taxonomy is most appropriate. You can see a mockup of this feature below

![prototype of filter dialog letting napari hub users filter plugins based on workflow step](https://github.com/chanzuckerberg/napari-hub/raw/main/docs/images/plugin_preview_demo.png)

We currently support viewing category metadata on the individual plugin pages, but before we let users filter by category, we want to get categories populated for as many plugins as possible.

For more information, see [A plugin developer’s guide to categories on the napari hub](https://github.com/chanzuckerberg/napari-hub/wiki/A-plugin-developer%E2%80%99s-guide-to-categories-on-the-napari-hub).

### Can you make adding category labels to my plugin easier?

Totally. We know that learning about the EDAM Bioimaging ontology and adding relevant categories is a lot of work. So we took a first pass for you! 

To help you get started, our team has reviewed your plugin’s description and metadata and identified category labels that we feel would be a good fit based on the information you’ve provided so far. These were proposed initially by our Biocuration Team who are experts in annotating scholarly literature with biological concepts, then reviewed by my colleague, @chili-chiu, an Application Scientist on our team.We did our best to select relevant labels, but we might be wrong! Please review and edit these categories to best fit your plugin… and let us know how we did! We’re exploring ways that we might be able to automate suggestions in the future for new plugin developers. We’ll be launching the “Filter by Category” feature on Jan 27, 2022, so if you’d like to take advantage of this new feature, please merge this PR by then!

### Can you let me preview the changes before I merge this PR?

Yeah, we can do that… not just for categories, but for all of your metadata!

To make it easier for you to update and maintain your plugin’s metadata, and see immediately how changes to links or your description will affect your napari hub listing, we’ve launched a new service that [lets you preview your plugin’s page directly from PRs](https://github.com/chanzuckerberg/napari-hub/issues/241) onto your plugin repository (like this one) and see what metadata you might be missing.

![Prototype of the napari hub Preview Page feature, which highlights missing metadata from your Github repository](https://user-images.githubusercontent.com/1245615/146843891-4f0cef00-78ab-4cd9-a5de-7f0a35be9ce8.png)

This service has two parts:

* A GitHub Action which parses your plugin’s metadata
* A GitHub App which provides a link to a preview of the plugin's napari hub page

To use the new Preview Page feature, you simply need to install the Github App by [clicking here](https://github.com/apps/napari-hub) and configuring it for this repository. Once you do that, make any update to this PR and you will get a comment from the @napari-hub-bot below with a link to your preview page! 

For more information, see [Setting Up Plugin Page Previews](https://github.com/chanzuckerberg/napari-hub/blob/main/docs/setting-up-preview.md)

We hope that these new features are useful to you! Happy to answer any questions here or on our [Discussions](https://github.com/chanzuckerberg/napari-hub/discussions) page.

