### PR TITLE
bugfix/mac_dropdown_box_fix

### DIFF
--- a/napari_allencell_segmenter/util/ui_utils.py
+++ b/napari_allencell_segmenter/util/ui_utils.py
@@ -12,6 +12,7 @@ class UiUtils:
         """
         dropdown = QComboBox()
         dropdown.setDisabled(not enabled)
+        dropdown.setStyleSheet("QComboBox { combobox-popup: 0; }")
         if placeholder is not None:
             dropdown.addItem(placeholder)
         if options is not None:

--- a/napari_allencell_segmenter/view/workflow_select_view.py
+++ b/napari_allencell_segmenter/view/workflow_select_view.py
@@ -60,10 +60,14 @@ class WorkflowSelectView(View):
         # Dropdowns
         layers_dropdown = UiUtils.dropdown_row("1.", "Select a 3D Napari image layer", enabled=False)
         self._combo_layers = layers_dropdown.widget
+        self._combo_layers.setStyleSheet("QComboBox { combobox-popup: 0; }")
+        self._combo_layers.setMaxVisibleItems(20)
         self._combo_layers.activated.connect(self._combo_layers_activated)
 
         channels_dropdown = UiUtils.dropdown_row("2.", "Select a 3D image data channel", enabled=False)
         self._combo_channels = channels_dropdown.widget
+        self._combo_channels.setStyleSheet("QComboBox { combobox-popup: 0; }")
+        self._combo_channels.setMaxVisibleItems(20)
         self._combo_channels.activated.connect(self._combo_channels_activated)
 
         layer_channel_selections = QWidget()

--- a/napari_allencell_segmenter/widgets/param_sweep_widget.py
+++ b/napari_allencell_segmenter/widgets/param_sweep_widget.py
@@ -112,6 +112,7 @@ class ParamSweepWidget(QDialog):
                     # for params that are a dropdown
                     if default_params[key][0].widget_type.name == "DROPDOWN":
                         dropdown = QComboBox()
+                        dropdown.setStyleSheet("QComboBox { combobox-popup: 0; }")
                         dropdown.addItems(default_params[key][0].options)
                         self.inputs[key] = dropdown
                         rows.append(FormRow(key, widget=dropdown))


### PR DESCRIPTION
Fixing weird behavior with dropdown boxes on macos. https://github.com/AllenCell/napari-allencell-segmenter/issues/135
related to this

> The property maxVisibleItems is ignored for non-editable comboboxes in styles that returns true for [`QStyle::SH_ComboBox_Popup`](http://qt-project.org/doc/qt-4.8/qstyle.html#StyleHint-enum)
