### PR TITLE
fix/Move-project-urls-to-setup.py

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,9 +1,3 @@
-project_urls:
-  Bug Tracker: https://github.com/AllenCell/napari-allencell-segmenter/issues
-  Documentation: https://github.com/AllenCell/napari-allencell-segmenter#README.md
-  Source Code: https://github.com/AllenCell/napari-allencell-segmenter
-  User Support: https://github.com/AllenCell/napari-allencell-segmenter/issues
-
 # Add labels from the EDAM Bioimaging ontology
 labels:
   ontology: EDAM-BIOIMAGING:alpha06

--- a/setup.py
+++ b/setup.py
@@ -118,10 +118,10 @@ setup(
         ],
     },
     project_urls={
-        "Bug Tracker": "https://github.com/AllenCell/napari-allencell-segmenter/issues"
-        "Documentation": "https://github.com/AllenCell/napari-allencell-segmenter#README.md"
-        "Source Code": "https://github.com/AllenCell/napari-allencell-segmenter"
-        "User Support": "https://github.com/AllenCell/napari-allencell-segmenter/issues"
+        "Bug Tracker": "https://github.com/AllenCell/napari-allencell-segmenter/issues",
+        "Documentation": "https://github.com/AllenCell/napari-allencell-segmenter#README.md",
+        "Source Code": "https://github.com/AllenCell/napari-allencell-segmenter",
+        "User Support": "https://github.com/AllenCell/napari-allencell-segmenter/issues",
     },
     # Do not edit this string manually, always use bumpversion
     # Details in CONTRIBUTING.rst

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,12 @@ setup(
             "napari-allencell-segmenter = napari_allencell_segmenter",
         ],
     },
+    project_urls={
+        "Bug Tracker": "https://github.com/AllenCell/napari-allencell-segmenter/issues"
+        "Documentation": "https://github.com/AllenCell/napari-allencell-segmenter#README.md"
+        "Source Code": "https://github.com/AllenCell/napari-allencell-segmenter"
+        "User Support": "https://github.com/AllenCell/napari-allencell-segmenter/issues"
+    },
     # Do not edit this string manually, always use bumpversion
     # Details in CONTRIBUTING.rst
     version="2.1.0-dev0",


### PR DESCRIPTION
Hello, in going through some napari plugins with missing metadata, I found your urls in the wrong place.  This fixes that.  Note that you can use `.napari/config.yaml` if you'd like to _override_ how your page appears on the hub, but you should mimimally populate the official sources for  [standard metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) 

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
